### PR TITLE
Fix newline handling in toolkit output

### DIFF
--- a/novel_toolkit5.py
+++ b/novel_toolkit5.py
@@ -251,9 +251,9 @@ def main() -> None:  # noqa: C901
 
             # Write outputs
             if md_fh and args.format in {"md", "both"} and args.mode != "entities":
-                md_fh.write(f"**{heading}**{response}")
+                md_fh.write(f"**{heading}**\n\n{response}\n")
             if json_fh and args.format in {"json", "both"} and data is not None:
-                json_fh.write(json.dumps(data, ensure_ascii=False) + "")
+                json_fh.write(json.dumps(data, ensure_ascii=False) + "\n")
 
             # Update entity memory for continuity
             if args.mode == "entities" and isinstance(data, dict):


### PR DESCRIPTION
## Summary
- add proper newlines when writing section summaries to Markdown
- append newline to JSONL entries

## Testing
- `python3 -m py_compile novel_toolkit5.py`


------
https://chatgpt.com/codex/tasks/task_e_6867d3b4b0008324ab019ddacf9788fc